### PR TITLE
Schedule Docker update more closely after the cache update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Dependency check builder
 on:
   schedule:
-    - cron:  '0 0 * * *' 
+    - cron:  '30 11 * * *' 
   workflow_dispatch:
     # Needed so we can run it manually
 jobs:


### PR DESCRIPTION
The cache is updated at 11 (i.e. 11am). If we only update the Docker image at midnight, the cached files would already be 13 hours old at build time. I don't see why such a delay should be necessary or desirable.

Ideally I think, the image should be built as a down stream workflow of the cache-update workflow.